### PR TITLE
Upgrade to GOBL v0.29.0

### DIFF
--- a/app/generators/ruby.rb
+++ b/app/generators/ruby.rb
@@ -11,6 +11,7 @@ require_relative 'ruby/object_from_gobl'
 require_relative 'ruby/object_to_gobl'
 require_relative 'ruby/object'
 require_relative 'ruby/string'
+require_relative 'ruby/any'
 
 # Define our custom inflections for Ruby conversion here
 ActiveSupport::Inflector.inflections do |inflect|
@@ -46,7 +47,9 @@ module Generators
     protected
 
     def schema_to_ruby(mods, name, schema, parent)
-      if schema.type.object?
+      if schema.type.nil?
+        Any.new(mods, name, schema, parent)
+      elsif schema.type.object?
         if schema.properties.empty?
           Map.new(mods, name, schema, parent)
         else

--- a/app/generators/ruby/any.rb
+++ b/app/generators/ruby/any.rb
@@ -1,0 +1,37 @@
+module Generators
+  class Ruby
+    # Base generator of a json schema of an unspecified type
+    class Any < Struct
+
+      def attributes
+        <<~EOFATTR
+          attribute :_value, GOBL::Types::Any
+        EOFATTR
+      end
+
+      def from_gobl_method
+        <<~EOFMETH
+          def self.from_gobl!(data)
+            new(_value: data)
+          end
+        EOFMETH
+      end
+
+      def to_gobl_method
+        <<~EOFMETH
+          def to_gobl
+            _value
+          end
+        EOFMETH
+      end
+
+      def additional_methods
+        <<~EOF
+          def to_s
+            _value.to_s
+          end
+        EOF
+      end
+    end
+  end
+end

--- a/lib/gobl/bill/advances.rb
+++ b/lib/gobl/bill/advances.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/charge.rb
+++ b/lib/gobl/bill/charge.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/charges.rb
+++ b/lib/gobl/bill/charges.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/delivery.rb
+++ b/lib/gobl/bill/delivery.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/discount.rb
+++ b/lib/gobl/bill/discount.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/discounts.rb
+++ b/lib/gobl/bill/discounts.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/exchange_rates.rb
+++ b/lib/gobl/bill/exchange_rates.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/invoice.rb
+++ b/lib/gobl/bill/invoice.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -25,7 +25,7 @@ module GOBL
       attribute :type_key, GOBL::Types::String.optional
 
       # Currency for all invoice totals.
-      attribute :currency, GOBL::Types::String
+      attribute :currency, GOBL::Currency::Code
 
       # Exchange rates to be used when converting the invoices monetary values into other currencies.
       attribute :exchange_rates, ExchangeRates.optional
@@ -86,7 +86,7 @@ module GOBL
           code: data['code'],
           series: data['series'],
           type_key: data['type_key'],
-          currency: data['currency'],
+          currency: GOBL::Currency::Code.from_gobl!(data['currency']),
           exchange_rates: data['exchange_rates'] ? ExchangeRates.from_gobl!(data['exchange_rates']) : nil,
           tax: data['tax'] ? Tax.from_gobl!(data['tax']) : nil,
           preceding: data['preceding'] ? Preceding.from_gobl!(data['preceding']) : nil,
@@ -118,7 +118,7 @@ module GOBL
           'code' => attributes[:code],
           'series' => attributes[:series],
           'type_key' => attributes[:type_key],
-          'currency' => attributes[:currency],
+          'currency' => attributes[:currency]&.to_gobl,
           'exchange_rates' => attributes[:exchange_rates]&.to_gobl,
           'tax' => attributes[:tax]&.to_gobl,
           'preceding' => attributes[:preceding]&.to_gobl,

--- a/lib/gobl/bill/line.rb
+++ b/lib/gobl/bill/line.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/line_charge.rb
+++ b/lib/gobl/bill/line_charge.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/line_discount.rb
+++ b/lib/gobl/bill/line_discount.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/lines.rb
+++ b/lib/gobl/bill/lines.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/ordering.rb
+++ b/lib/gobl/bill/ordering.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/outlay.rb
+++ b/lib/gobl/bill/outlay.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/outlays.rb
+++ b/lib/gobl/bill/outlays.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/payment.rb
+++ b/lib/gobl/bill/payment.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/preceding.rb
+++ b/lib/gobl/bill/preceding.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/scheme_keys.rb
+++ b/lib/gobl/bill/scheme_keys.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/tax.rb
+++ b/lib/gobl/bill/tax.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/totals.rb
+++ b/lib/gobl/bill/totals.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/cal/date.rb
+++ b/lib/gobl/cal/date.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/cal/period.rb
+++ b/lib/gobl/cal/period.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/currency/code.rb
+++ b/lib/gobl/currency/code.rb
@@ -9,18 +9,13 @@
 require 'dry-struct'
 
 module GOBL
-  module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+  module Currency
+    # ISO Currency Code
+    class Code < Dry::Struct
+      attribute :_value, GOBL::Types::Any
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +23,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/currency/exchange_rate.rb
+++ b/lib/gobl/currency/exchange_rate.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -13,7 +13,7 @@ module GOBL
     # ExchangeRate contains data on the rate to be used when converting amounts from the document's base currency to whatever is defined.
     class ExchangeRate < Dry::Struct
       # ISO currency code this rate represents.
-      attribute :currency, GOBL::Types::String
+      attribute :currency, GOBL::Currency::Code
 
       # How much is 1.00 of this currency worth in the documents currency.
       attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
@@ -22,7 +22,7 @@ module GOBL
         data = GOBL::Types::Hash[data]
 
         new(
-          currency: data['currency'],
+          currency: GOBL::Currency::Code.from_gobl!(data['currency']),
           amount: data['amount']
         )
       end
@@ -33,7 +33,7 @@ module GOBL
 
       def to_gobl
         {
-          'currency' => attributes[:currency],
+          'currency' => attributes[:currency]&.to_gobl,
           'amount' => attributes[:amount]&.to_gobl
         }
       end

--- a/lib/gobl/document.rb
+++ b/lib/gobl/document.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/dsig/digest.rb
+++ b/lib/gobl/dsig/digest.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/dsig/signature.rb
+++ b/lib/gobl/dsig/signature.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/envelope.rb
+++ b/lib/gobl/envelope.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/header.rb
+++ b/lib/gobl/header.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/i18n/string.rb
+++ b/lib/gobl/i18n/string.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/l10n/code.rb
+++ b/lib/gobl/l10n/code.rb
@@ -9,18 +9,13 @@
 require 'dry-struct'
 
 module GOBL
-  module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+  module L10n
+    # Code is used for short identifies like country or state codes.
+    class Code < Dry::Struct
+      attribute :_value, GOBL::Types::String
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +23,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/l10n/country_code.rb
+++ b/lib/gobl/l10n/country_code.rb
@@ -9,18 +9,12 @@
 require 'dry-struct'
 
 module GOBL
-  module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+  module L10n
+    class CountryCode < Dry::Struct
+      attribute :_value, GOBL::Types::Any
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +22,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/note/message.rb
+++ b/lib/gobl/note/message.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/address.rb
+++ b/lib/gobl/org/address.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -12,9 +12,10 @@ module GOBL
   module Org
     # Address defines a globally acceptable set of attributes that describes a postal or fiscal address.
     class Address < Dry::Struct
+      # Internal ID used to identify the party inside a document.
       attribute :uuid, GOBL::UUID::UUID.optional
 
-      # Useful identifier
+      # Useful identifier, such as home, work, etc.
       attribute :label, GOBL::Types::String.optional
 
       # Box number or code for the post office box located at the address.
@@ -32,27 +33,28 @@ module GOBL
       # Door number within the building.
       attribute :door, GOBL::Types::String.optional
 
-      # Fist line of street.
+      # First line of street.
       attribute :street, GOBL::Types::String.optional
 
       # Additional street address details.
       attribute :street_extra, GOBL::Types::String.optional
 
-      # The village
+      # The village, town, district, or city.
       attribute :locality, GOBL::Types::String
 
-      # Province
+      # Province, County, or State.
       attribute :region, GOBL::Types::String
 
       # Post or ZIP code.
       attribute :code, GOBL::Types::String.optional
 
       # ISO country code.
-      attribute :country, GOBL::Types::String.optional
+      attribute :country, GOBL::L10n::CountryCode.optional
 
-      # For when the postal address is not sufficient
+      # When the postal address is not sufficient, coordinates help locate the address more precisely.
       attribute :coords, GOBL::Org::Coordinates.optional
 
+      # Any additional semi-structure details about the address.
       attribute :meta, GOBL::Org::Meta.optional
 
       def self.from_gobl!(data)
@@ -71,7 +73,7 @@ module GOBL
           locality: data['locality'],
           region: data['region'],
           code: data['code'],
-          country: data['country'],
+          country: data['country'] ? GOBL::L10n::CountryCode.from_gobl!(data['country']) : nil,
           coords: data['coords'] ? GOBL::Org::Coordinates.from_gobl!(data['coords']) : nil,
           meta: data['meta'] ? GOBL::Org::Meta.from_gobl!(data['meta']) : nil
         )
@@ -95,7 +97,7 @@ module GOBL
           'locality' => attributes[:locality],
           'region' => attributes[:region],
           'code' => attributes[:code],
-          'country' => attributes[:country],
+          'country' => attributes[:country]&.to_gobl,
           'coords' => attributes[:coords]&.to_gobl,
           'meta' => attributes[:meta]&.to_gobl
         }

--- a/lib/gobl/org/code.rb
+++ b/lib/gobl/org/code.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/coordinates.rb
+++ b/lib/gobl/org/coordinates.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/email.rb
+++ b/lib/gobl/org/email.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/inbox.rb
+++ b/lib/gobl/org/inbox.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/item.rb
+++ b/lib/gobl/org/item.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -30,14 +30,14 @@ module GOBL
       # Base price of a single unit to be sold.
       attribute :price, GOBL::Types.Constructor(GOBL::Num::Amount)
 
-      # Free-text unit of measure.
-      attribute :unit, GOBL::Types::String.optional
+      # Unit of measure.
+      attribute :unit, GOBL::Org::Unit.optional
 
       # List of additional codes, IDs, or SKUs which can be used to identify the item. The should be agreed upon between supplier and customer.
       attribute :codes, GOBL::Types::Array.of(ItemCode).optional
 
       # Country code of where this item was from originally.
-      attribute :origin, GOBL::Types::String.optional
+      attribute :origin, GOBL::L10n::CountryCode.optional
 
       # Additional meta information that may be useful
       attribute :meta, GOBL::Org::Meta.optional
@@ -52,9 +52,9 @@ module GOBL
           desc: data['desc'],
           currency: data['currency'],
           price: data['price'],
-          unit: data['unit'],
+          unit: data['unit'] ? GOBL::Org::Unit.from_gobl!(data['unit']) : nil,
           codes: data['codes']&.map { |item| ItemCode.from_gobl!(item) },
-          origin: data['origin'],
+          origin: data['origin'] ? GOBL::L10n::CountryCode.from_gobl!(data['origin']) : nil,
           meta: data['meta'] ? GOBL::Org::Meta.from_gobl!(data['meta']) : nil
         )
       end
@@ -71,9 +71,9 @@ module GOBL
           'desc' => attributes[:desc],
           'currency' => attributes[:currency],
           'price' => attributes[:price]&.to_gobl,
-          'unit' => attributes[:unit],
+          'unit' => attributes[:unit]&.to_gobl,
           'codes' => attributes[:codes]&.map { |item| item&.to_gobl },
-          'origin' => attributes[:origin],
+          'origin' => attributes[:origin]&.to_gobl,
           'meta' => attributes[:meta]&.to_gobl
         }
       end

--- a/lib/gobl/org/item_code.rb
+++ b/lib/gobl/org/item_code.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/key.rb
+++ b/lib/gobl/org/key.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/meta.rb
+++ b/lib/gobl/org/meta.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/name.rb
+++ b/lib/gobl/org/name.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/note.rb
+++ b/lib/gobl/org/note.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -13,7 +13,7 @@ module GOBL
     # Note represents a free text of additional information that may be added to a document.
     class Note < Dry::Struct
       # Key specifying subject of the text
-      attribute :key, GOBL::Org::Key.optional
+      attribute :key, NoteKey.optional
 
       # Code used for additional data that may be required to identify the note.
       attribute :code, GOBL::Types::String.optional
@@ -28,7 +28,7 @@ module GOBL
         data = GOBL::Types::Hash[data]
 
         new(
-          key: data['key'] ? GOBL::Org::Key.from_gobl!(data['key']) : nil,
+          key: data['key'] ? NoteKey.from_gobl!(data['key']) : nil,
           code: data['code'],
           src: data['src'],
           text: data['text']

--- a/lib/gobl/org/note_key.rb
+++ b/lib/gobl/org/note_key.rb
@@ -9,18 +9,13 @@
 require 'dry-struct'
 
 module GOBL
-  module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+  module Org
+    # NoteKey identifies the type of note being edited
+    class NoteKey < Dry::Struct
+      attribute :_value, GOBL::Types::Any
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +23,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/org/notes.rb
+++ b/lib/gobl/org/notes.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/party.rb
+++ b/lib/gobl/org/party.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/person.rb
+++ b/lib/gobl/org/person.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/registration.rb
+++ b/lib/gobl/org/registration.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/source_key.rb
+++ b/lib/gobl/org/source_key.rb
@@ -9,18 +9,13 @@
 require 'dry-struct'
 
 module GOBL
-  module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+  module Org
+    # SourceKey identifies the source of a tax identity
+    class SourceKey < Dry::Struct
+      attribute :_value, GOBL::Types::Any
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +23,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/org/tax_identity.rb
+++ b/lib/gobl/org/tax_identity.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -16,13 +16,13 @@ module GOBL
       attribute :uuid, GOBL::UUID::UUID.optional
 
       # ISO country code for Where the tax identity was issued.
-      attribute :country, GOBL::Types::String
+      attribute :country, GOBL::L10n::CountryCode
 
       # Where inside a country the Tax ID was issued, if required.
-      attribute :locality, GOBL::Types::String.optional
+      attribute :locality, GOBL::L10n::Code.optional
 
       # What is the source document of this tax identity.
-      attribute :document, GOBL::Org::Key.optional
+      attribute :source, SourceKey.optional
 
       # Tax identity Code
       attribute :code, GOBL::Types::String.optional
@@ -35,9 +35,9 @@ module GOBL
 
         new(
           uuid: data['uuid'] ? GOBL::UUID::UUID.from_gobl!(data['uuid']) : nil,
-          country: data['country'],
-          locality: data['locality'],
-          document: data['document'] ? GOBL::Org::Key.from_gobl!(data['document']) : nil,
+          country: GOBL::L10n::CountryCode.from_gobl!(data['country']),
+          locality: data['locality'] ? GOBL::L10n::Code.from_gobl!(data['locality']) : nil,
+          source: data['source'] ? SourceKey.from_gobl!(data['source']) : nil,
           code: data['code'],
           meta: data['meta'] ? GOBL::Org::Meta.from_gobl!(data['meta']) : nil
         )
@@ -50,9 +50,9 @@ module GOBL
       def to_gobl
         {
           'uuid' => attributes[:uuid]&.to_gobl,
-          'country' => attributes[:country],
-          'locality' => attributes[:locality],
-          'document' => attributes[:document]&.to_gobl,
+          'country' => attributes[:country]&.to_gobl,
+          'locality' => attributes[:locality]&.to_gobl,
+          'source' => attributes[:source]&.to_gobl,
           'code' => attributes[:code],
           'meta' => attributes[:meta]&.to_gobl
         }

--- a/lib/gobl/org/telephone.rb
+++ b/lib/gobl/org/telephone.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/unit.rb
+++ b/lib/gobl/org/unit.rb
@@ -9,18 +9,13 @@
 require 'dry-struct'
 
 module GOBL
-  module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+  module Org
+    # Unit describes how the quantity of the product should be interpreted.
+    class Unit < Dry::Struct
+      attribute :_value, GOBL::Types::Any
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +23,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/pay/advance.rb
+++ b/lib/gobl/pay/advance.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -34,7 +34,7 @@ module GOBL
       attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
 
       # If different from the parent document's base currency.
-      attribute :currency, GOBL::Types::String.optional
+      attribute :currency, GOBL::Currency::Code.optional
 
       def self.from_gobl!(data)
         data = GOBL::Types::Hash[data]
@@ -47,7 +47,7 @@ module GOBL
           desc: data['desc'],
           percent: data['percent'] ? data['percent'] : nil,
           amount: data['amount'],
-          currency: data['currency']
+          currency: data['currency'] ? GOBL::Currency::Code.from_gobl!(data['currency']) : nil
         )
       end
 
@@ -64,7 +64,7 @@ module GOBL
           'desc' => attributes[:desc],
           'percent' => attributes[:percent]&.to_gobl,
           'amount' => attributes[:amount]&.to_gobl,
-          'currency' => attributes[:currency]
+          'currency' => attributes[:currency]&.to_gobl
         }
       end
 

--- a/lib/gobl/pay/card.rb
+++ b/lib/gobl/pay/card.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/credit_transfer.rb
+++ b/lib/gobl/pay/credit_transfer.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/direct_debit.rb
+++ b/lib/gobl/pay/direct_debit.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/due_date.rb
+++ b/lib/gobl/pay/due_date.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -25,7 +25,7 @@ module GOBL
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
       # If different from the parent document's base currency.
-      attribute :currency, GOBL::Types::String.optional
+      attribute :currency, GOBL::Currency::Code.optional
 
       def self.from_gobl!(data)
         data = GOBL::Types::Hash[data]
@@ -35,7 +35,7 @@ module GOBL
           notes: data['notes'],
           amount: data['amount'],
           percent: data['percent'] ? data['percent'] : nil,
-          currency: data['currency']
+          currency: data['currency'] ? GOBL::Currency::Code.from_gobl!(data['currency']) : nil
         )
       end
 
@@ -49,7 +49,7 @@ module GOBL
           'notes' => attributes[:notes],
           'amount' => attributes[:amount]&.to_gobl,
           'percent' => attributes[:percent]&.to_gobl,
-          'currency' => attributes[:currency]
+          'currency' => attributes[:currency]&.to_gobl
         }
       end
 

--- a/lib/gobl/pay/instructions.rb
+++ b/lib/gobl/pay/instructions.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -13,7 +13,7 @@ module GOBL
     # Instructions holds a set of instructions that determine how the payment has or should be made.
     class Instructions < Dry::Struct
       # How payment is expected or has been arranged to be collected
-      attribute :key, GOBL::Org::Key
+      attribute :key, MethodKey
 
       # Optional text description of the payment method
       attribute :detail, GOBL::Types::String.optional
@@ -43,7 +43,7 @@ module GOBL
         data = GOBL::Types::Hash[data]
 
         new(
-          key: GOBL::Org::Key.from_gobl!(data['key']),
+          key: MethodKey.from_gobl!(data['key']),
           detail: data['detail'],
           ref: data['ref'],
           credit_transfer: data['credit_transfer']&.map { |item| CreditTransfer.from_gobl!(item) },

--- a/lib/gobl/pay/method_key.rb
+++ b/lib/gobl/pay/method_key.rb
@@ -9,18 +9,13 @@
 require 'dry-struct'
 
 module GOBL
-  module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+  module Pay
+    # Method Key describes how a payment should be made
+    class MethodKey < Dry::Struct
+      attribute :_value, GOBL::Types::Any
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +23,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/pay/online.rb
+++ b/lib/gobl/pay/online.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/term_key.rb
+++ b/lib/gobl/pay/term_key.rb
@@ -9,18 +9,13 @@
 require 'dry-struct'
 
 module GOBL
-  module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+  module Pay
+    # Payment terms key
+    class TermKey < Dry::Struct
+      attribute :_value, GOBL::Types::Any
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +23,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/pay/terms.rb
+++ b/lib/gobl/pay/terms.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -13,7 +13,7 @@ module GOBL
     # Terms defines when we expect the customer to pay, or have paid, for the contents of the document.
     class Terms < Dry::Struct
       # Type of terms to be applied.
-      attribute :key, GOBL::Org::Key
+      attribute :key, TermKey
 
       # Text detail of the chosen payment terms.
       attribute :detail, GOBL::Types::String.optional
@@ -28,7 +28,7 @@ module GOBL
         data = GOBL::Types::Hash[data]
 
         new(
-          key: GOBL::Org::Key.from_gobl!(data['key']),
+          key: TermKey.from_gobl!(data['key']),
           detail: data['detail'],
           due_dates: data['due_dates']&.map { |item| DueDate.from_gobl!(item) },
           notes: data['notes']

--- a/lib/gobl/stamp.rb
+++ b/lib/gobl/stamp.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/category.rb
+++ b/lib/gobl/tax/category.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/category_total.rb
+++ b/lib/gobl/tax/category_total.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/combo.rb
+++ b/lib/gobl/tax/combo.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/localities.rb
+++ b/lib/gobl/tax/localities.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/locality.rb
+++ b/lib/gobl/tax/locality.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -13,7 +13,7 @@ module GOBL
     # Locality represents an area inside a region, like a province or a state, which shares the basic definitions of the region, but may vary in some validation rules.
     class Locality < Dry::Struct
       # Code
-      attribute :code, GOBL::Types::String
+      attribute :code, GOBL::L10n::Code
 
       # Name of the locality with local and hopefully international translations.
       attribute :name, GOBL::I18n::String
@@ -25,7 +25,7 @@ module GOBL
         data = GOBL::Types::Hash[data]
 
         new(
-          code: data['code'],
+          code: GOBL::L10n::Code.from_gobl!(data['code']),
           name: GOBL::I18n::String.from_gobl!(data['name']),
           meta: data['meta'] ? GOBL::Org::Meta.from_gobl!(data['meta']) : nil
         )
@@ -37,7 +37,7 @@ module GOBL
 
       def to_gobl
         {
-          'code' => attributes[:code],
+          'code' => attributes[:code]&.to_gobl,
           'name' => attributes[:name]&.to_gobl,
           'meta' => attributes[:meta]&.to_gobl
         }

--- a/lib/gobl/tax/note.rb
+++ b/lib/gobl/tax/note.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -13,7 +13,7 @@ module GOBL
     # Note represents a free text of additional information that may be added to a document.
     class Note < Dry::Struct
       # Key specifying subject of the text
-      attribute :key, GOBL::Org::Key.optional
+      attribute :key, NoteKey.optional
 
       # Code used for additional data that may be required to identify the note.
       attribute :code, GOBL::Types::String.optional
@@ -28,7 +28,7 @@ module GOBL
         data = GOBL::Types::Hash[data]
 
         new(
-          key: data['key'] ? GOBL::Org::Key.from_gobl!(data['key']) : nil,
+          key: data['key'] ? NoteKey.from_gobl!(data['key']) : nil,
           code: data['code'],
           src: data['src'],
           text: data['text']

--- a/lib/gobl/tax/note_key.rb
+++ b/lib/gobl/tax/note_key.rb
@@ -10,17 +10,12 @@ require 'dry-struct'
 
 module GOBL
   module Tax
-    # Schemes defines an array of scheme objects with helper functions.
-    class Schemes < Dry::Struct
-      extend Forwardable
-      include Enumerable
-
-      attribute :_ary, GOBL::Types::Array.of(Scheme)
-
-      def_delegators :_ary, :[], :each, :empty?, :length, :find
+    # NoteKey identifies the type of note being edited
+    class NoteKey < Dry::Struct
+      attribute :_value, GOBL::Types::Any
 
       def self.from_gobl!(data)
-        new(_ary: data&.map { |item| Scheme.from_gobl!(item) } )
+        new(_value: data)
       end
 
       def self.from_json!(json)
@@ -28,11 +23,15 @@ module GOBL
       end
 
       def to_gobl
-        _ary
+        _value
       end
 
       def to_json(options = nil)
         JSON.generate(to_gobl, options)
+      end
+
+      def to_s
+        _value.to_s
       end
     end
   end

--- a/lib/gobl/tax/rate.rb
+++ b/lib/gobl/tax/rate.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/rate_total.rb
+++ b/lib/gobl/tax/rate_total.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/rate_total_surcharge.rb
+++ b/lib/gobl/tax/rate_total_surcharge.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/rate_value.rb
+++ b/lib/gobl/tax/rate_value.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/region.rb
+++ b/lib/gobl/tax/region.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'
@@ -16,16 +16,16 @@ module GOBL
       attribute :name, GOBL::I18n::String
 
       # Country code for the region
-      attribute :country, GOBL::Types::String
+      attribute :country, GOBL::L10n::CountryCode
 
       # Locality, city, province, county, or similar code inside the country, if needed.
-      attribute :locality, GOBL::Types::String.optional
+      attribute :locality, GOBL::L10n::Code.optional
 
       # List of sub-localities inside a region.
       attribute :localities, Localities.optional
 
       # Currency used by the region for tax purposes.
-      attribute :currency, GOBL::Types::String
+      attribute :currency, GOBL::Currency::Code
 
       # Set of specific scheme definitions inside the region.
       attribute :schemes, Schemes.optional
@@ -38,10 +38,10 @@ module GOBL
 
         new(
           name: GOBL::I18n::String.from_gobl!(data['name']),
-          country: data['country'],
-          locality: data['locality'],
+          country: GOBL::L10n::CountryCode.from_gobl!(data['country']),
+          locality: data['locality'] ? GOBL::L10n::Code.from_gobl!(data['locality']) : nil,
           localities: data['localities'] ? Localities.from_gobl!(data['localities']) : nil,
-          currency: data['currency'],
+          currency: GOBL::Currency::Code.from_gobl!(data['currency']),
           schemes: data['schemes'] ? Schemes.from_gobl!(data['schemes']) : nil,
           categories: data['categories']&.map { |item| Category.from_gobl!(item) }
         )
@@ -54,10 +54,10 @@ module GOBL
       def to_gobl
         {
           'name' => attributes[:name]&.to_gobl,
-          'country' => attributes[:country],
-          'locality' => attributes[:locality],
+          'country' => attributes[:country]&.to_gobl,
+          'locality' => attributes[:locality]&.to_gobl,
           'localities' => attributes[:localities]&.to_gobl,
-          'currency' => attributes[:currency],
+          'currency' => attributes[:currency]&.to_gobl,
           'schemes' => attributes[:schemes]&.to_gobl,
           'categories' => attributes[:categories]&.map { |item| item&.to_gobl }
         }

--- a/lib/gobl/tax/scheme.rb
+++ b/lib/gobl/tax/scheme.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/set.rb
+++ b/lib/gobl/tax/set.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/total.rb
+++ b/lib/gobl/tax/total.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/lib/gobl/uuid/uuid.rb
+++ b/lib/gobl/uuid/uuid.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.28.1
+## Generated with GOBL v0.29.0
 ##
 
 require 'dry-struct'

--- a/spec/gobl/l10n/country_code_spec.rb
+++ b/spec/gobl/l10n/country_code_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../../../lib/gobl'
+
+RSpec.describe GOBL::L10n::CountryCode do
+  it 'creates a new country code from a JSON' do
+    obj = 'ES'
+    any = described_class.from_json!(obj.to_json)
+
+    expect(any.to_s).to eq('ES')
+  end
+end


### PR DESCRIPTION
The main change of v0.29.0 is adding [controlled values to several keys and codes](https://github.com/invopop/gobl/pull/63) in the schema (e.g. CountryCode, Unit). This change in the schema broke the previous Ruby code generator, which expected all the definitions to have a `type`. The definition for the controlled keys and codes didn't have a type as they are implemented as compositions using the `anyOf` and `oneOf` keywords.

This PR implements the most basic way of supporting this type of JSONSchema's definitions by simply storing them as an `Any` dry-struct type. This is consistent with how other JSONSchema code generator deal with this type of definitions (e.g. [quicktype](https://app.quicktype.io) or [shale](https://github.com/kgiszczak/shale)).

This implementation doesn't take advantage of the information about the valid values of the affected keys and codes. `dry-types` supports [enumerations](https://dry-rb.org/gems/dry-types/1.0/enum/), which we could use to validate the values of these types, for example. This is something we can tackle in a follow-up PR, but I'd like to discuss the approach to do it first as, strictly speaking, in the JSONSchema, these are [compositions](https://json-schema.org/understanding-json-schema/reference/combining.html) not [enumerations](https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values).

I tested locally that the `pdf` service works with this version of the gem without requiring any change. I'll open a PR in that repo as soon as these changes get merged to `main`.