### PR TITLE
Upgrade to GOBL v0.30.2

### DIFF
--- a/lib/gobl/bill/advances.rb
+++ b/lib/gobl/bill/advances.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/charge.rb
+++ b/lib/gobl/bill/charge.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -15,7 +15,7 @@ module GOBL
       # Unique identifying for the discount entry
       attribute :uuid, GOBL::UUID::UUID.optional
 
-      # Line number inside the list of discounts
+      # Line number inside the list of discounts (calculated).
       attribute :i, GOBL::Types::Int
 
       # Code to used to refer to the this charge
@@ -27,7 +27,7 @@ module GOBL
       # Percentage to apply to the invoice's Sum
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
-      # Amount to apply
+      # Amount to apply (calculated if percent present)
       attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
 
       # List of taxes to apply to the charge

--- a/lib/gobl/bill/charges.rb
+++ b/lib/gobl/bill/charges.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/delivery.rb
+++ b/lib/gobl/bill/delivery.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/discount.rb
+++ b/lib/gobl/bill/discount.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -15,7 +15,7 @@ module GOBL
       # Unique identifying for the discount entry
       attribute :uuid, GOBL::UUID::UUID.optional
 
-      # Line number inside the list of discounts
+      # Line number inside the list of discounts (calculated)
       attribute :i, GOBL::Types::Int
 
       # Reference or ID for this Discount
@@ -24,10 +24,10 @@ module GOBL
       # Base represents the value used as a base for percent calculations. If not already provided, we'll take the invoices sum.
       attribute :base, GOBL::Types.Constructor(GOBL::Num::Amount).optional
 
-      # Percentage to apply to the invoice's Sum
+      # Percentage to apply to the invoice's Sum.
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
-      # Amount to apply
+      # Amount to apply (calculated if percent present).
       attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
 
       # List of taxes to apply to the discount

--- a/lib/gobl/bill/discounts.rb
+++ b/lib/gobl/bill/discounts.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/exchange_rates.rb
+++ b/lib/gobl/bill/exchange_rates.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/invoice.rb
+++ b/lib/gobl/bill/invoice.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -21,8 +21,8 @@ module GOBL
       # Used in addition to the Code in some regions.
       attribute :series, GOBL::Types::String.optional
 
-      # Functional type of the invoice, default is always 'commercial'.
-      attribute :type_key, GOBL::Types::String.optional
+      # Optional invoice type, leave empty unless needed for a specific situation.
+      attribute :type, InvoiceType.optional
 
       # Currency for all invoice totals.
       attribute :currency, GOBL::Currency::Code
@@ -69,7 +69,7 @@ module GOBL
 
       attribute :delivery, Delivery.optional
 
-      # Summary of all the invoice totals, including taxes.
+      # Summary of all the invoice totals, including taxes (calculated).
       attribute :totals, Totals
 
       # Unstructured information that is relevant to the invoice, such as correction or additional legal details.
@@ -85,7 +85,7 @@ module GOBL
           uuid: data['uuid'] ? GOBL::UUID::UUID.from_gobl!(data['uuid']) : nil,
           code: data['code'],
           series: data['series'],
-          type_key: data['type_key'],
+          type: data['type'] ? InvoiceType.from_gobl!(data['type']) : nil,
           currency: GOBL::Currency::Code.from_gobl!(data['currency']),
           exchange_rates: data['exchange_rates'] ? ExchangeRates.from_gobl!(data['exchange_rates']) : nil,
           tax: data['tax'] ? Tax.from_gobl!(data['tax']) : nil,
@@ -117,7 +117,7 @@ module GOBL
           'uuid' => attributes[:uuid]&.to_gobl,
           'code' => attributes[:code],
           'series' => attributes[:series],
-          'type_key' => attributes[:type_key],
+          'type' => attributes[:type]&.to_gobl,
           'currency' => attributes[:currency]&.to_gobl,
           'exchange_rates' => attributes[:exchange_rates]&.to_gobl,
           'tax' => attributes[:tax]&.to_gobl,

--- a/lib/gobl/bill/invoice_type.rb
+++ b/lib/gobl/bill/invoice_type.rb
@@ -9,20 +9,17 @@
 require 'dry-struct'
 
 module GOBL
-  module Pay
-    # Payment terms key
-    class TermKey < Dry::Struct
+  module Bill
+    # Defines an invoice type according to a subset of the UNTDID 1001 standard list.
+    class InvoiceType < Dry::Struct
       ENUM = {
-        '' => 'Not yet defined',
-        'end-of-month' => 'End of month',
-        'due-date' => 'Due on a specific date',
-        'deferred' => 'Deferred until after the due date',
-        'proximo' => 'Month after the present',
-        'instant' => 'On receipt of invoice',
-        'elective' => 'Chosen by the buyer',
-        'pending' => 'Seller to advise buyer in separate transaction',
-        'advance' => 'Payment made in advance',
-        'delivery' => 'Payment on Delivery'
+        'proforma' => 'Proforma invoice, for a clients validation before sending a final invoice.',
+        'simplified' => 'Simplified invoice or receipt typically used for small transactions that dont require customer details.t require customer details.',
+        'partial' => 'Partial invoice',
+        'commercial' => 'Commercial invoice, usually cross-border transactions requiring an invoice for customs.',
+        'corrected' => 'Corrected invoice',
+        'credit-note' => 'Credit note',
+        'self-billed' => 'Self billed invoice'
       }
 
       attribute :_value, GOBL::Types::String.enum(*ENUM.keys)

--- a/lib/gobl/bill/line.rb
+++ b/lib/gobl/bill/line.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -15,7 +15,7 @@ module GOBL
       # Unique identifier for this line
       attribute :uuid, GOBL::UUID::UUID.optional
 
-      # Line number inside the parent
+      # Line number inside the parent (calculated)
       attribute :i, GOBL::Types::Int
 
       # Number of items
@@ -24,7 +24,7 @@ module GOBL
       # Details about what is being sold
       attribute :item, GOBL::Org::Item
 
-      # Result of quantity multiplied by the item's price
+      # Result of quantity multiplied by the item's price (calculated)
       attribute :sum, GOBL::Types.Constructor(GOBL::Num::Amount)
 
       # Discounts applied to this line
@@ -36,7 +36,7 @@ module GOBL
       # Map of taxes to be applied and used in the invoice totals
       attribute :taxes, GOBL::Tax::Set.optional
 
-      # Total line amount after applying discounts to the sum.
+      # Total line amount after applying discounts to the sum (calculated).
       attribute :total, GOBL::Types.Constructor(GOBL::Num::Amount)
 
       # Set of specific notes for this line that may be required for clarification.

--- a/lib/gobl/bill/line_charge.rb
+++ b/lib/gobl/bill/line_charge.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -15,7 +15,7 @@ module GOBL
       # Percentage if fixed amount not applied
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
-      # Fixed or resulting charge amount to apply
+      # Fixed or resulting charge amount to apply (calculated if percent present).
       attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
 
       # Reference code.

--- a/lib/gobl/bill/line_discount.rb
+++ b/lib/gobl/bill/line_discount.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -15,7 +15,7 @@ module GOBL
       # Percentage if fixed amount not applied
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
-      # Fixed discount amount to apply
+      # Fixed discount amount to apply (calculated if percent present).
       attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
 
       # Reason code.

--- a/lib/gobl/bill/lines.rb
+++ b/lib/gobl/bill/lines.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/ordering.rb
+++ b/lib/gobl/bill/ordering.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/outlay.rb
+++ b/lib/gobl/bill/outlay.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -15,7 +15,7 @@ module GOBL
       # Unique identity for this outlay.
       attribute :uuid, GOBL::UUID::UUID.optional
 
-      # Outlay number index inside the invoice for ordering.
+      # Outlay number index inside the invoice for ordering (calculated).
       attribute :i, GOBL::Types::Int
 
       # When was the outlay made.

--- a/lib/gobl/bill/outlays.rb
+++ b/lib/gobl/bill/outlays.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/payment.rb
+++ b/lib/gobl/bill/payment.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/preceding.rb
+++ b/lib/gobl/bill/preceding.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/scheme_keys.rb
+++ b/lib/gobl/bill/scheme_keys.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/tax.rb
+++ b/lib/gobl/bill/tax.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/bill/totals.rb
+++ b/lib/gobl/bill/totals.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/cal/date.rb
+++ b/lib/gobl/cal/date.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/cal/period.rb
+++ b/lib/gobl/cal/period.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/currency/code.rb
+++ b/lib/gobl/currency/code.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -181,7 +181,7 @@ module GOBL
         'ZWL' => 'Zimbabwe Dollar'
       }
 
-      attribute :_value, GOBL::Types::Any.enum(*ENUM.keys)
+      attribute :_value, GOBL::Types::String.enum(*ENUM.keys)
 
       def self.from_gobl!(data)
         new(_value: data)

--- a/lib/gobl/currency/exchange_rate.rb
+++ b/lib/gobl/currency/exchange_rate.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/document.rb
+++ b/lib/gobl/document.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/dsig/digest.rb
+++ b/lib/gobl/dsig/digest.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/dsig/signature.rb
+++ b/lib/gobl/dsig/signature.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/envelope.rb
+++ b/lib/gobl/envelope.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/header.rb
+++ b/lib/gobl/header.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/i18n/string.rb
+++ b/lib/gobl/i18n/string.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/l10n/code.rb
+++ b/lib/gobl/l10n/code.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/l10n/country_code.rb
+++ b/lib/gobl/l10n/country_code.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -263,7 +263,7 @@ module GOBL
         'ZW' => 'Zimbabwe'
       }
 
-      attribute :_value, GOBL::Types::Any.enum(*ENUM.keys)
+      attribute :_value, GOBL::Types::String.enum(*ENUM.keys)
 
       def self.from_gobl!(data)
         new(_value: data)

--- a/lib/gobl/note/message.rb
+++ b/lib/gobl/note/message.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/address.rb
+++ b/lib/gobl/org/address.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/code.rb
+++ b/lib/gobl/org/code.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/coordinates.rb
+++ b/lib/gobl/org/coordinates.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/email.rb
+++ b/lib/gobl/org/email.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/inbox.rb
+++ b/lib/gobl/org/inbox.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/item.rb
+++ b/lib/gobl/org/item.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/item_code.rb
+++ b/lib/gobl/org/item_code.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/key.rb
+++ b/lib/gobl/org/key.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/meta.rb
+++ b/lib/gobl/org/meta.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/name.rb
+++ b/lib/gobl/org/name.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/note.rb
+++ b/lib/gobl/org/note.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/note_key.rb
+++ b/lib/gobl/org/note_key.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -40,7 +40,7 @@ module GOBL
         'tax' => 'Tax declaration'
       }
 
-      attribute :_value, GOBL::Types::Any.enum(*ENUM.keys)
+      attribute :_value, GOBL::Types::String.enum(*ENUM.keys)
 
       def self.from_gobl!(data)
         new(_value: data)

--- a/lib/gobl/org/notes.rb
+++ b/lib/gobl/org/notes.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/party.rb
+++ b/lib/gobl/org/party.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/person.rb
+++ b/lib/gobl/org/person.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/registration.rb
+++ b/lib/gobl/org/registration.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/source_key.rb
+++ b/lib/gobl/org/source_key.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -20,7 +20,7 @@ module GOBL
         'other' => 'An other type of source not listed'
       }
 
-      attribute :_value, GOBL::Types::Any.enum(*ENUM.keys)
+      attribute :_value, GOBL::Types::String.enum(*ENUM.keys)
 
       def self.from_gobl!(data)
         new(_value: data)

--- a/lib/gobl/org/tax_identity.rb
+++ b/lib/gobl/org/tax_identity.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/telephone.rb
+++ b/lib/gobl/org/telephone.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/org/unit.rb
+++ b/lib/gobl/org/unit.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -63,7 +63,7 @@ module GOBL
         'envelope' => 'Envelopes'
       }
 
-      attribute :_value, GOBL::Types::Any
+      attribute :_value, GOBL::Types::String
 
       def self.from_gobl!(data)
         new(_value: data)

--- a/lib/gobl/pay/advance.rb
+++ b/lib/gobl/pay/advance.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/card.rb
+++ b/lib/gobl/pay/card.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/credit_transfer.rb
+++ b/lib/gobl/pay/credit_transfer.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/direct_debit.rb
+++ b/lib/gobl/pay/direct_debit.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/due_date.rb
+++ b/lib/gobl/pay/due_date.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/instructions.rb
+++ b/lib/gobl/pay/instructions.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/method_key.rb
+++ b/lib/gobl/pay/method_key.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -22,7 +22,7 @@ module GOBL
         'online' => 'Online or web payment'
       }
 
-      attribute :_value, GOBL::Types::Any.enum(*ENUM.keys)
+      attribute :_value, GOBL::Types::String.enum(*ENUM.keys)
 
       def self.from_gobl!(data)
         new(_value: data)

--- a/lib/gobl/pay/online.rb
+++ b/lib/gobl/pay/online.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/pay/terms.rb
+++ b/lib/gobl/pay/terms.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/stamp.rb
+++ b/lib/gobl/stamp.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -11,8 +11,8 @@ require 'dry-struct'
 module GOBL
   # Stamp defines an official seal of approval from a third party like a governmental agency or intermediary and should thus be included in any official envelopes.
   class Stamp < Dry::Struct
-    # Identity of the agency used to create the stamp
-    attribute :prv, GOBL::Types::String
+    # Identity of the agency used to create the stamp usually defined by each region.
+    attribute :prv, GOBL::Org::Key
 
     # The serialized stamp value generated for or by the external agency
     attribute :val, GOBL::Types::String
@@ -21,7 +21,7 @@ module GOBL
       data = GOBL::Types::Hash[data]
 
       new(
-        prv: data['prv'],
+        prv: GOBL::Org::Key.from_gobl!(data['prv']),
         val: data['val']
       )
     end
@@ -32,7 +32,7 @@ module GOBL
 
     def to_gobl
       {
-        'prv' => attributes[:prv],
+        'prv' => attributes[:prv]&.to_gobl,
         'val' => attributes[:val]
       }
     end

--- a/lib/gobl/tax/category.rb
+++ b/lib/gobl/tax/category.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/category_total.rb
+++ b/lib/gobl/tax/category_total.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/combo.rb
+++ b/lib/gobl/tax/combo.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -18,10 +18,10 @@ module GOBL
       # Rate within a category to apply.
       attribute :rate, GOBL::Org::Key.optional
 
-      # Percent defines the percentage set manually or determined from the rate key.
+      # Percent defines the percentage set manually or determined from the rate key (calculated if rate present).
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage)
 
-      # Some countries require an additional surcharge.
+      # Some countries require an additional surcharge (calculated if rate present).
       attribute :surcharge, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
       def self.from_gobl!(data)

--- a/lib/gobl/tax/localities.rb
+++ b/lib/gobl/tax/localities.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/locality.rb
+++ b/lib/gobl/tax/locality.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/note.rb
+++ b/lib/gobl/tax/note.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/note_key.rb
+++ b/lib/gobl/tax/note_key.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'
@@ -40,7 +40,7 @@ module GOBL
         'tax' => 'Tax declaration'
       }
 
-      attribute :_value, GOBL::Types::Any.enum(*ENUM.keys)
+      attribute :_value, GOBL::Types::String.enum(*ENUM.keys)
 
       def self.from_gobl!(data)
         new(_value: data)

--- a/lib/gobl/tax/rate.rb
+++ b/lib/gobl/tax/rate.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/rate_total.rb
+++ b/lib/gobl/tax/rate_total.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/rate_total_surcharge.rb
+++ b/lib/gobl/tax/rate_total_surcharge.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/rate_value.rb
+++ b/lib/gobl/tax/rate_value.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/region.rb
+++ b/lib/gobl/tax/region.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/scheme.rb
+++ b/lib/gobl/tax/scheme.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/schemes.rb
+++ b/lib/gobl/tax/schemes.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/set.rb
+++ b/lib/gobl/tax/set.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/tax/total.rb
+++ b/lib/gobl/tax/total.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'

--- a/lib/gobl/uuid/uuid.rb
+++ b/lib/gobl/uuid/uuid.rb
@@ -3,7 +3,7 @@
 ##
 ## DO NOT EDIT - This file was generated automatically.
 ##
-## Generated with GOBL v0.29.0
+## Generated with GOBL v0.30.2
 ##
 
 require 'dry-struct'


### PR DESCRIPTION
* Just a regeneration of the structs. No changes were necessary in the generators or the library to make it work with the latest GOBL version.
* There are backwards compatibility breaking changes in the new schema version and thus in the generated structs.
* The new version of the schema set the type `string` for composed keys and codes. The type of the related generated attributes is now `String` rather than `Any`.
* The new version of the schema flags calculated attributes. For the moment, the Ruby generated code ignores that flag (this will change in a future PR)