### PR TITLE
Make calculated fields optional

### DIFF
--- a/app/generators/ruby/object.rb
+++ b/app/generators/ruby/object.rb
@@ -22,7 +22,7 @@ module Generators
         out = ''
         desc = property.description&.split&.join(' ')
         out << "# #{desc}\n" if desc.present?
-        ts = property_as_type(name, property, !schema.required?(name))
+        ts = property_as_type(name, property, schema.optional?(name))
         out << "attribute :#{safe_property_name(name)}, #{ts}\n"
         out
       end

--- a/app/generators/ruby/object_from_gobl.rb
+++ b/app/generators/ruby/object_from_gobl.rb
@@ -37,7 +37,7 @@ module Generators
 
       def property_key_value_pair(name, property)
         var = "#{PARAM_NAME}['#{name}']"
-        txt = property_value_string(property, var, !schema.required?(name))
+        txt = property_value_string(property, var, schema.optional?(name))
         # explicitely define symbol so we avoid errors with `$schema` or `$id`
         "#{safe_property_name(name)}: #{txt}"
       end

--- a/app/parser/schema.rb
+++ b/app/parser/schema.rb
@@ -70,5 +70,13 @@ module Parser
       composition_data = @data.slice('anyOf', 'oneOf', 'allOf').first
       composition_data.present? ? Composition.new(*composition_data) : nil
     end
+
+    def calculated?
+      @data['calculated'] || false
+    end
+
+    def optional?(property_name)
+      !required?(property_name) || properties[property_name].calculated?
+    end
   end
 end

--- a/lib/gobl/bill/charge.rb
+++ b/lib/gobl/bill/charge.rb
@@ -16,7 +16,7 @@ module GOBL
       attribute :uuid, GOBL::UUID::UUID.optional
 
       # Line number inside the list of discounts (calculated).
-      attribute :i, GOBL::Types::Int
+      attribute :i, GOBL::Types::Int.optional
 
       # Code to used to refer to the this charge
       attribute :ref, GOBL::Types::String.optional
@@ -28,7 +28,7 @@ module GOBL
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
       # Amount to apply (calculated if percent present)
-      attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
+      attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount).optional
 
       # List of taxes to apply to the charge
       attribute :taxes, GOBL::Tax::Set.optional
@@ -51,7 +51,7 @@ module GOBL
           ref: data['ref'],
           base: data['base'] ? data['base'] : nil,
           percent: data['percent'] ? data['percent'] : nil,
-          amount: data['amount'],
+          amount: data['amount'] ? data['amount'] : nil,
           taxes: data['taxes'] ? GOBL::Tax::Set.from_gobl!(data['taxes']) : nil,
           code: data['code'],
           reason: data['reason'],

--- a/lib/gobl/bill/discount.rb
+++ b/lib/gobl/bill/discount.rb
@@ -16,7 +16,7 @@ module GOBL
       attribute :uuid, GOBL::UUID::UUID.optional
 
       # Line number inside the list of discounts (calculated)
-      attribute :i, GOBL::Types::Int
+      attribute :i, GOBL::Types::Int.optional
 
       # Reference or ID for this Discount
       attribute :ref, GOBL::Types::String.optional
@@ -28,7 +28,7 @@ module GOBL
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
       # Amount to apply (calculated if percent present).
-      attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
+      attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount).optional
 
       # List of taxes to apply to the discount
       attribute :taxes, GOBL::Tax::Set.optional
@@ -51,7 +51,7 @@ module GOBL
           ref: data['ref'],
           base: data['base'] ? data['base'] : nil,
           percent: data['percent'] ? data['percent'] : nil,
-          amount: data['amount'],
+          amount: data['amount'] ? data['amount'] : nil,
           taxes: data['taxes'] ? GOBL::Tax::Set.from_gobl!(data['taxes']) : nil,
           code: data['code'],
           reason: data['reason'],

--- a/lib/gobl/bill/invoice.rb
+++ b/lib/gobl/bill/invoice.rb
@@ -70,7 +70,7 @@ module GOBL
       attribute :delivery, Delivery.optional
 
       # Summary of all the invoice totals, including taxes (calculated).
-      attribute :totals, Totals
+      attribute :totals, Totals.optional
 
       # Unstructured information that is relevant to the invoice, such as correction or additional legal details.
       attribute :notes, GOBL::Org::Notes.optional
@@ -102,7 +102,7 @@ module GOBL
           ordering: data['ordering'] ? Ordering.from_gobl!(data['ordering']) : nil,
           payment: data['payment'] ? Payment.from_gobl!(data['payment']) : nil,
           delivery: data['delivery'] ? Delivery.from_gobl!(data['delivery']) : nil,
-          totals: Totals.from_gobl!(data['totals']),
+          totals: data['totals'] ? Totals.from_gobl!(data['totals']) : nil,
           notes: data['notes'] ? GOBL::Org::Notes.from_gobl!(data['notes']) : nil,
           meta: data['meta'] ? GOBL::Org::Meta.from_gobl!(data['meta']) : nil
         )

--- a/lib/gobl/bill/line.rb
+++ b/lib/gobl/bill/line.rb
@@ -16,7 +16,7 @@ module GOBL
       attribute :uuid, GOBL::UUID::UUID.optional
 
       # Line number inside the parent (calculated)
-      attribute :i, GOBL::Types::Int
+      attribute :i, GOBL::Types::Int.optional
 
       # Number of items
       attribute :quantity, GOBL::Types.Constructor(GOBL::Num::Amount)
@@ -25,7 +25,7 @@ module GOBL
       attribute :item, GOBL::Org::Item
 
       # Result of quantity multiplied by the item's price (calculated)
-      attribute :sum, GOBL::Types.Constructor(GOBL::Num::Amount)
+      attribute :sum, GOBL::Types.Constructor(GOBL::Num::Amount).optional
 
       # Discounts applied to this line
       attribute :discounts, GOBL::Types::Array.of(LineDiscount).optional
@@ -37,7 +37,7 @@ module GOBL
       attribute :taxes, GOBL::Tax::Set.optional
 
       # Total line amount after applying discounts to the sum (calculated).
-      attribute :total, GOBL::Types.Constructor(GOBL::Num::Amount)
+      attribute :total, GOBL::Types.Constructor(GOBL::Num::Amount).optional
 
       # Set of specific notes for this line that may be required for clarification.
       attribute :notes, GOBL::Org::Notes.optional
@@ -50,11 +50,11 @@ module GOBL
           i: data['i'],
           quantity: data['quantity'],
           item: GOBL::Org::Item.from_gobl!(data['item']),
-          sum: data['sum'],
+          sum: data['sum'] ? data['sum'] : nil,
           discounts: data['discounts']&.map { |item| LineDiscount.from_gobl!(item) },
           charges: data['charges']&.map { |item| LineCharge.from_gobl!(item) },
           taxes: data['taxes'] ? GOBL::Tax::Set.from_gobl!(data['taxes']) : nil,
-          total: data['total'],
+          total: data['total'] ? data['total'] : nil,
           notes: data['notes'] ? GOBL::Org::Notes.from_gobl!(data['notes']) : nil
         )
       end

--- a/lib/gobl/bill/line_charge.rb
+++ b/lib/gobl/bill/line_charge.rb
@@ -16,7 +16,7 @@ module GOBL
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
       # Fixed or resulting charge amount to apply (calculated if percent present).
-      attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
+      attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount).optional
 
       # Reference code.
       attribute :code, GOBL::Types::String.optional
@@ -29,7 +29,7 @@ module GOBL
 
         new(
           percent: data['percent'] ? data['percent'] : nil,
-          amount: data['amount'],
+          amount: data['amount'] ? data['amount'] : nil,
           code: data['code'],
           reason: data['reason']
         )

--- a/lib/gobl/bill/line_discount.rb
+++ b/lib/gobl/bill/line_discount.rb
@@ -16,7 +16,7 @@ module GOBL
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
       # Fixed discount amount to apply (calculated if percent present).
-      attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)
+      attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount).optional
 
       # Reason code.
       attribute :code, GOBL::Types::String.optional
@@ -29,7 +29,7 @@ module GOBL
 
         new(
           percent: data['percent'] ? data['percent'] : nil,
-          amount: data['amount'],
+          amount: data['amount'] ? data['amount'] : nil,
           code: data['code'],
           reason: data['reason']
         )

--- a/lib/gobl/bill/outlay.rb
+++ b/lib/gobl/bill/outlay.rb
@@ -16,7 +16,7 @@ module GOBL
       attribute :uuid, GOBL::UUID::UUID.optional
 
       # Outlay number index inside the invoice for ordering (calculated).
-      attribute :i, GOBL::Types::Int
+      attribute :i, GOBL::Types::Int.optional
 
       # When was the outlay made.
       attribute :date, GOBL::Cal::Date.optional

--- a/lib/gobl/tax/combo.rb
+++ b/lib/gobl/tax/combo.rb
@@ -19,7 +19,7 @@ module GOBL
       attribute :rate, GOBL::Org::Key.optional
 
       # Percent defines the percentage set manually or determined from the rate key (calculated if rate present).
-      attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage)
+      attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 
       # Some countries require an additional surcharge (calculated if rate present).
       attribute :surcharge, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
@@ -30,7 +30,7 @@ module GOBL
         new(
           cat: GOBL::Org::Code.from_gobl!(data['cat']),
           rate: data['rate'] ? GOBL::Org::Key.from_gobl!(data['rate']) : nil,
-          percent: data['percent'],
+          percent: data['percent'] ? data['percent'] : nil,
           surcharge: data['surcharge'] ? data['surcharge'] : nil
         )
       end

--- a/spec/example/uncalculated_invoice.json
+++ b/spec/example/uncalculated_invoice.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "code": "SAMPLE-001",
+    "currency": "EUR",
+    "issue_date": "2022-02-01",
+    "supplier": {
+        "tax_id": {
+            "country": "ES",
+            "code": "54387763P"
+        },
+        "name": "Provide One S.L."
+    },
+    "customer": {
+        "tax_id": {
+            "country": "ES",
+            "code": "54387763P"
+        },
+        "name": "Sample Consumer"
+    },
+    "lines": [
+        {
+            "quantity": "20",
+            "item": {
+                "name": "Development services",
+                "price": "90.00"
+            }
+        }
+    ]
+}

--- a/spec/gobl/document_spec.rb
+++ b/spec/gobl/document_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/gobl'
+
+RSpec.describe GOBL::Document do
+  it 'extracts documents without calculated fields' do
+    gobl = File.read('spec/example/uncalculated_invoice.json')
+    doc = described_class.from_json!(gobl)
+
+    invoice = doc.extract
+
+    expect(invoice.code).to eq('SAMPLE-001')
+    expect(invoice.totals).to be_blank # Totals are calculated and missing in the document
+  end
+end


### PR DESCRIPTION
* Using the `calculated` tag in the json schema properties, we make the related attributes in the structs optional. 
* This will allow to instantiate documents and envelops that haven't been calculated yet so that you can run operations (like build) over them (btw, the `build` operation is almost finished too and there will be a PR soon)