### PR TITLE
`GOBL::validate` and `GOBL::sign` operations

### DIFF
--- a/lib/gobl/operations.rb
+++ b/lib/gobl/operations.rb
@@ -25,9 +25,8 @@ module GOBL
   #   invoice = built_doc.extract
   #   invoice.totals.total.to_s #=> "1800.00"
   module Operations
-    class ServiceError < StandardError; end
-
     BUILDABLE_TYPES = [GOBL::Document, GOBL::Envelope].freeze
+    VALIDATABLE_TYPES = [GOBL::Document, GOBL::Envelope].freeze
 
     # Calculates and validates an envelope or document, wrapping it in an envelope if
     # requested.
@@ -62,11 +61,46 @@ module GOBL
     def build(struct, envelop: nil, draft: nil)
       check_struct_type struct, BUILDABLE_TYPES
 
-      payload = request_action(:build, struct: struct,
-                                       envelop: envelop,
-                                       draft: draft)
+      response = request_action(:build, struct: struct,
+                                        envelop: envelop,
+                                        draft: draft)
 
-      GOBL::Struct.from_gobl! payload
+      raise ServiceError, response['error'] if response['error'].present?
+
+      GOBL::Struct.from_gobl! response['payload']
+    end
+
+    # Checks whether or not a document or envelope is valid according to the GOBL schema
+    #   and rules.
+    #
+    # @param struct [GOBL::Document, GOBL::Envelope] the document or the envelope to
+    #   validate.
+    #
+    # @return [GOBL::ValidationResult] the result of the validations.
+    #
+    # @example Validate an invalid document.
+    #   document =  GOBL::Document.from_json!(File.read('invalid_invoice.json'))
+    #   result = GOBL.validate(document)
+    #   result.valid? #=> false
+    #   result.errors #=> ['code: cannot be blank', 'totals: cannot be blank']
+    #
+    # @example Validate a valid envelope.
+    #   envelope = GOBL::Envelop.from_json!(File.read('valid_envelope.json'))
+    #   result = GOBL.validate(envelope)
+    #   result.valid? #=> true
+    #   result.errors #=> []
+    def validate(struct)
+      check_struct_type struct, VALIDATABLE_TYPES
+
+      response = request_action(:validate, struct: struct)
+
+      if response['error'].present?
+        ValidationResult.from_service_error(response['error'])
+      elsif response['payload']['ok']
+        ValidationResult.valid
+      else
+        raise 'Unexpected response from the service'
+      end
     end
 
     private
@@ -80,11 +114,7 @@ module GOBL
       response.error! unless response.is_a?(Net::HTTPSuccess)
 
       parts = parse_bulk_response(response)
-      part = parts.first # We're only requesting one action, the response is the first part
-
-      raise ServiceError, part["error"] if part["error"].present?
-
-      part["payload"]
+      parts.first # We're only requesting one action, the response is the first part
     end
 
     def build_bulk_request(action, struct, params)

--- a/lib/gobl/operations/service_error.rb
+++ b/lib/gobl/operations/service_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module GOBL
+  module Operations
+    class ServiceError < StandardError
+    end
+  end
+end

--- a/lib/gobl/operations/validation_result.rb
+++ b/lib/gobl/operations/validation_result.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module GOBL
+  module Operations
+    # The result of a GOBL validation over a GOBL structure
+    class ValidationResult
+      SERVICE_ERROR_REGEX = /^code=(?<code>\d+), message=(?<msg>.+)$/.freeze
+
+      def initialize(errors)
+        @errors = errors
+      end
+
+      # Whether the GOBL structure were valid or not
+      #
+      # @return [Boolean]
+      def valid?
+        @errors.empty?
+      end
+
+      # The list of errors found in the GOBL structure
+      #
+      # @return [Array]
+      def errors
+        @errors || []
+      end
+
+      # Builds a new `ValidationResult` object resulted from parsing the service
+      #   error response given as a parameter
+      #
+      # @param service_error [String]
+      # @return [ValidationResult]
+      def self.from_service_error(service_error)
+        message = service_error.match(SERVICE_ERROR_REGEX)[:msg]
+        errors = message.split('; ')
+        new errors
+      end
+
+      # Builds a new `ValidationResult` object for a positive `validate` operation
+      #
+      # @return [ValidationResult]
+      def self.valid
+        new []
+      end
+    end
+  end
+end

--- a/mage.go
+++ b/mage.go
@@ -34,6 +34,7 @@ func dockerRunCmd(name, publicPort string, cmd ...string) error {
 		"--network", "invopop-local",
 		"-v", "$PWD:/app",
 		"-v", "$PWD/.tmp_bundle:/usr/local/bundle",
+		"-v", "$PWD/spec/support/keys:/root/.gobl",
 		"-w", "/app",
 		"-it", // interactive
 		// "--entrypoint=rake",

--- a/spec/gobl/operations_spec.rb
+++ b/spec/gobl/operations_spec.rb
@@ -75,4 +75,45 @@ RSpec.describe GOBL::Operations do
       expect { GOBL.build(header) }.to raise_error(ArgumentError)
     end
   end
+
+  describe '#validate' do
+    it 'validates an invalid document' do
+      gobl = File.read('spec/example/uncalculated_invoice.json')
+      doc = GOBL::Document.from_json!(gobl)
+
+      result = GOBL.validate(doc)
+
+      expect(result).not_to be_valid
+      expect(result.errors).to include('totals: cannot be blank.')
+    end
+
+    it 'validates a valid envelope' do
+      gobl = File.read('spec/example/message_envelope.json')
+      doc = GOBL::Envelope.from_json!(gobl)
+
+      result = GOBL.validate(doc)
+
+      expect(result).to be_valid
+      expect(result.errors).to be_blank
+    end
+
+    it 'validates invalid documents' do
+      invalid_docs = [
+        GOBL::Document.from_gobl!({}),
+        GOBL::Document.from_gobl!('$schema' => 'https://gobl.org/draft-0/bill/invoice')
+      ]
+
+      invalid_docs.each do |struct|
+        result = GOBL.validate(struct)
+        expect(result).not_to be_valid
+      end
+    end
+
+    it 'fails when an unsupported struct is given' do
+      gobl = File.read('spec/example/basic_header.json')
+      header = GOBL::Header.from_json!(gobl)
+
+      expect { GOBL.validate(header) }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/support/keys/id_es256.jwk
+++ b/spec/support/keys/id_es256.jwk
@@ -1,0 +1,1 @@
+{"use":"sig","kty":"EC","kid":"c5b201f2-cc21-4126-8029-a27a0ab22225","crv":"P-256","alg":"ES256","x":"5y46c2DVmeURdXD4wmHe-nzZJAZNRTM7lceroP9JUcw","y":"dvOC_1pqj0AV4Vx9WKqQoQ9uKR4C8Yjy_dup1ScJaq0","d":"uUtVQ1rJmv-clEKGVzFKZYFUJquyOfhPPmMGM5M7ais"}

--- a/spec/support/keys/id_es256.pub.jwk
+++ b/spec/support/keys/id_es256.pub.jwk
@@ -1,0 +1,1 @@
+{"use":"sig","kty":"EC","kid":"c5b201f2-cc21-4126-8029-a27a0ab22225","crv":"P-256","alg":"ES256","x":"5y46c2DVmeURdXD4wmHe-nzZJAZNRTM7lceroP9JUcw","y":"dvOC_1pqj0AV4Vx9WKqQoQ9uKR4C8Yjy_dup1ScJaq0"}


### PR DESCRIPTION
* This PR adds the `validate` and `sign` operations to the library, bringing the ability to validate and sign GOBL documents and envelops to Ruby developers
* It follows the general approach described in ["RFC: GOBL Operations from Ruby"](https://app.gitbook.com/o/BAmNkVk3FlSXU68ubIB9/s/cR28Ws8uYp3Goe7bTjRW/projects/gobl/rfc-gobl-operations-from-ruby).
* Signing is done using the private key configured in the service (see invopop/gobl.cli#65). The client cannot specify a custom private key.