### PR TITLE
Embedding structs into documents

### DIFF
--- a/app/generators/ruby/struct.rb
+++ b/app/generators/ruby/struct.rb
@@ -21,6 +21,8 @@ module Generators
         out << "# #{schema.description}\n" if schema.description.present?
         out << <<~EOFMOD
           class #{class_name} < #{parent_class}
+            #{schema_id_const}
+
           #{indent(class_content, 1).chomp}
           end
         EOFMOD
@@ -29,6 +31,10 @@ module Generators
 
       def parent_class
         "GOBL::Struct"
+      end
+
+      def schema_id_const
+        "SCHEMA_ID = '#{parent.definition_schema_id(name)}'"
       end
 
       def class_content

--- a/app/parser/id.rb
+++ b/app/parser/id.rb
@@ -38,5 +38,9 @@ module Parser
     def to_s
       @id.to_s
     end
+
+    def ==(other)
+      to_s == other.to_s
+    end
   end
 end

--- a/app/parser/schema.rb
+++ b/app/parser/schema.rb
@@ -78,5 +78,12 @@ module Parser
     def optional?(property_name)
       !required?(property_name) || properties[property_name].calculated?
     end
+
+    def definition_schema_id(name)
+      pointer = ID.new("#/$defs/#{name}")
+      pointer = nil if pointer == ref
+
+      ID.new([id, pointer].join)
+    end
   end
 end

--- a/lib/gobl/bill/advances.rb
+++ b/lib/gobl/bill/advances.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Advances contains an array of advance objects.
     class Advances < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Advances'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/bill/charge.rb
+++ b/lib/gobl/bill/charge.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Charge represents a surchange applied to the complete document independent from the individual lines.
     class Charge < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Charge'
+
       # Unique identifying for the discount entry
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/bill/charges.rb
+++ b/lib/gobl/bill/charges.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Charges represents an array of charge objects
     class Charges < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Charges'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/bill/delivery.rb
+++ b/lib/gobl/bill/delivery.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Delivery covers the details of the destination for the products described in the invoice body.
     class Delivery < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Delivery'
+
       # The party who will receive delivery of the goods defined in the invoice and is not responsible for taxes.
       attribute? :receiver, GOBL::Org::Party.optional
 

--- a/lib/gobl/bill/discount.rb
+++ b/lib/gobl/bill/discount.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Discount represents an allowance applied to the complete document independent from the individual lines.
     class Discount < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Discount'
+
       # Unique identifying for the discount entry
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/bill/discounts.rb
+++ b/lib/gobl/bill/discounts.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Discounts represents an array of discounts.
     class Discounts < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Discounts'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/bill/exchange_rates.rb
+++ b/lib/gobl/bill/exchange_rates.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # ExchangeRates represents an array of currency exchange rates.
     class ExchangeRates < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/ExchangeRates'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/bill/invoice.rb
+++ b/lib/gobl/bill/invoice.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Invoice represents a payment claim for goods or services supplied under conditions agreed between the supplier and the customer.
     class Invoice < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice'
+
       # Unique document ID. Not required, but always recommended in addition to the Code.
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/bill/invoice_type.rb
+++ b/lib/gobl/bill/invoice_type.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Defines an invoice type according to a subset of the UNTDID 1001 standard list.
     class InvoiceType < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/InvoiceType'
+
       ENUM = {
         'proforma' => 'Proforma invoice, for a clients validation before sending a final invoice.',
         'simplified' => 'Simplified invoice or receipt typically used for small transactions that dont require customer details.t require customer details.',

--- a/lib/gobl/bill/line.rb
+++ b/lib/gobl/bill/line.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Line is a single row in an invoice.
     class Line < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Line'
+
       # Unique identifier for this line
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/bill/line_charge.rb
+++ b/lib/gobl/bill/line_charge.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # LineCharge represents an amount added to the line, and will be applied before taxes.
     class LineCharge < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/LineCharge'
+
       # Percentage if fixed amount not applied
       attribute? :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 

--- a/lib/gobl/bill/line_discount.rb
+++ b/lib/gobl/bill/line_discount.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # LineDiscount represents an amount deducted from the line, and will be applied before taxes.
     class LineDiscount < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/LineDiscount'
+
       # Percentage if fixed amount not applied
       attribute? :percent, GOBL::Types.Constructor(GOBL::Num::Percentage).optional
 

--- a/lib/gobl/bill/lines.rb
+++ b/lib/gobl/bill/lines.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Lines holds an array of Line objects.
     class Lines < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Lines'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/bill/ordering.rb
+++ b/lib/gobl/bill/ordering.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Ordering allows additional order details to be appended
     class Ordering < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Ordering'
+
       # Party who is selling the goods and is not responsible for taxes
       attribute? :seller, GOBL::Org::Party.optional
 

--- a/lib/gobl/bill/outlay.rb
+++ b/lib/gobl/bill/outlay.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Outlay represents a reimbursable expense that was paid for by the supplier and invoiced separately by the third party directly to the customer.
     class Outlay < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Outlay'
+
       # Unique identity for this outlay.
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/bill/outlays.rb
+++ b/lib/gobl/bill/outlays.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Outlays holds an array of Outlay objects used inside a billing document.
     class Outlays < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Outlays'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/bill/payment.rb
+++ b/lib/gobl/bill/payment.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Payment contains details as to how the invoice should be paid.
     class Payment < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Payment'
+
       # The party responsible for paying for the invoice, if not the customer.
       attribute? :payer, GOBL::Org::Party.optional
 

--- a/lib/gobl/bill/preceding.rb
+++ b/lib/gobl/bill/preceding.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Preceding allows for information to be provided about a previous invoice that this one will replace or subtract from.
     class Preceding < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Preceding'
+
       # Preceding document's UUID if available can be useful for tracing.
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/bill/scheme_keys.rb
+++ b/lib/gobl/bill/scheme_keys.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # SchemeKeys stores a list of keys that makes it easier to perform matches.
     class SchemeKeys < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/SchemeKeys'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/bill/tax.rb
+++ b/lib/gobl/bill/tax.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Tax defines a summary of the taxes which may be applied to an invoice.
     class Tax < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Tax'
+
       # Category of the tax already included in the line item prices, especially useful for B2C retailers with customers who prefer final prices inclusive of tax.
       attribute? :prices_include, GOBL::Org::Code.optional
 

--- a/lib/gobl/bill/totals.rb
+++ b/lib/gobl/bill/totals.rb
@@ -10,6 +10,8 @@ module GOBL
   module Bill
     # Totals contains the summaries of all calculations for the invoice.
     class Totals < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/bill/invoice#/$defs/Totals'
+
       # Sum of all line item sums
       attribute :sum, GOBL::Types.Constructor(GOBL::Num::Amount)
 

--- a/lib/gobl/cal/date.rb
+++ b/lib/gobl/cal/date.rb
@@ -10,6 +10,8 @@ module GOBL
   module Cal
     # Civil date in simplified ISO format, like 2021-05-26
     class Date < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/cal/date'
+
       attribute :_value, GOBL::Types::String
       private :_value
 

--- a/lib/gobl/cal/period.rb
+++ b/lib/gobl/cal/period.rb
@@ -10,6 +10,8 @@ module GOBL
   module Cal
     # Period represents two dates with a start and finish.
     class Period < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/cal/period'
+
       attribute :start, GOBL::Cal::Date
 
       attribute :end, GOBL::Cal::Date

--- a/lib/gobl/currency/code.rb
+++ b/lib/gobl/currency/code.rb
@@ -10,6 +10,8 @@ module GOBL
   module Currency
     # ISO Currency Code
     class Code < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/currency/code'
+
       ENUM = {
         'AED' => 'UAE Dirham',
         'AFN' => 'Afghani',

--- a/lib/gobl/currency/exchange_rate.rb
+++ b/lib/gobl/currency/exchange_rate.rb
@@ -10,6 +10,8 @@ module GOBL
   module Currency
     # ExchangeRate contains data on the rate to be used when converting amounts from the document's base currency to whatever is defined.
     class ExchangeRate < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/currency/exchange-rate'
+
       # ISO currency code this rate represents.
       attribute :currency, GOBL::Currency::Code
 

--- a/lib/gobl/document.rb
+++ b/lib/gobl/document.rb
@@ -9,6 +9,8 @@
 module GOBL
   # Contents of the envelope that must contain a $schema.
   class Document < GOBL::Struct
+    SCHEMA_ID = 'https://gobl.org/draft-0/envelope#/$defs/Document'
+
     extend Forwardable
     include Enumerable
 

--- a/lib/gobl/dsig/digest.rb
+++ b/lib/gobl/dsig/digest.rb
@@ -10,6 +10,8 @@ module GOBL
   module DSig
     # Digest defines a structure to hold a digest value including the algorithm used to generate it.
     class Digest < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/dsig/digest'
+
       # Algorithm stores the algorithm key that was used to generate the value.
       attribute :alg, GOBL::Types::String
 

--- a/lib/gobl/dsig/signature.rb
+++ b/lib/gobl/dsig/signature.rb
@@ -10,6 +10,8 @@ module GOBL
   module DSig
     # JSON Web Signature in compact form.
     class Signature < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/dsig/signature'
+
       attribute :_value, GOBL::Types::String
       private :_value
 

--- a/lib/gobl/envelope.rb
+++ b/lib/gobl/envelope.rb
@@ -9,6 +9,8 @@
 module GOBL
   # Envelope wraps around a gobl document and provides support for digest creation and digital signatures.
   class Envelope < GOBL::Struct
+    SCHEMA_ID = 'https://gobl.org/draft-0/envelope'
+
     # Schema identifies the schema that should be used to understand this document
     attribute :schema, GOBL::Types::String
 

--- a/lib/gobl/header.rb
+++ b/lib/gobl/header.rb
@@ -9,6 +9,8 @@
 module GOBL
   # Header defines the meta data of the body.
   class Header < GOBL::Struct
+    SCHEMA_ID = 'https://gobl.org/draft-0/envelope#/$defs/Header'
+
     # Unique UUIDv1 identifier for the envelope.
     attribute :uuid, GOBL::UUID::UUID
 

--- a/lib/gobl/i18n/string.rb
+++ b/lib/gobl/i18n/string.rb
@@ -10,6 +10,8 @@ module GOBL
   module I18n
     # Map of 2-Letter language codes to their translations.
     class String < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/i18n/string'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/l10n/code.rb
+++ b/lib/gobl/l10n/code.rb
@@ -10,6 +10,8 @@ module GOBL
   module L10n
     # Code is used for short identifies like country or state codes.
     class Code < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/l10n/code'
+
       attribute :_value, GOBL::Types::String
       private :_value
 

--- a/lib/gobl/l10n/country_code.rb
+++ b/lib/gobl/l10n/country_code.rb
@@ -9,6 +9,8 @@
 module GOBL
   module L10n
     class CountryCode < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/l10n/country-code'
+
       ENUM = {
         'AF' => 'Afghanistan',
         'AX' => 'Åland Islands',

--- a/lib/gobl/note/message.rb
+++ b/lib/gobl/note/message.rb
@@ -10,6 +10,8 @@ module GOBL
   module Note
     # Message represents the minimum possible contents for a GoBL document type.
     class Message < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/note/message'
+
       # Summary of the message content
       attribute? :title, GOBL::Types::String.optional
 

--- a/lib/gobl/org/address.rb
+++ b/lib/gobl/org/address.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Address defines a globally acceptable set of attributes that describes a postal or fiscal address.
     class Address < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/address'
+
       # Internal ID used to identify the party inside a document.
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/org/code.rb
+++ b/lib/gobl/org/code.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Short upper-case identifier.
     class Code < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/code'
+
       attribute :_value, GOBL::Types::String
       private :_value
 

--- a/lib/gobl/org/coordinates.rb
+++ b/lib/gobl/org/coordinates.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Coordinates describes an exact geographical location in the world.
     class Coordinates < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/coordinates'
+
       # Decimal latitude coordinate.
       attribute? :lat, GOBL::Types::Double.optional
 

--- a/lib/gobl/org/email.rb
+++ b/lib/gobl/org/email.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Email describes the electronic mailing details.
     class Email < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/email'
+
       # Unique identity code
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/org/inbox.rb
+++ b/lib/gobl/org/inbox.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Inbox is used to store data about a connection with a service that is responsible for potentially receiving copies of GOBL envelopes or other document formats defined locally.
     class Inbox < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/inbox'
+
       # Unique ID. Useful if inbox is stored in a database.
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/org/item.rb
+++ b/lib/gobl/org/item.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Item is used to describe a single product or service.
     class Item < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/item'
+
       # Unique identify of this item independent of the Supplier IDs
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/org/item_code.rb
+++ b/lib/gobl/org/item_code.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # ItemCode contains a value and optional label property that means additional codes can be added to an item.
     class ItemCode < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/item#/$defs/ItemCode'
+
       # Local or human reference for the type of code the value represents.
       attribute? :label, GOBL::Types::String.optional
 

--- a/lib/gobl/org/key.rb
+++ b/lib/gobl/org/key.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Text identifier to be used instead of a code for a more verbose but readable identifier.
     class Key < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/key'
+
       attribute :_value, GOBL::Types::String
       private :_value
 

--- a/lib/gobl/org/meta.rb
+++ b/lib/gobl/org/meta.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Meta defines a structure for data about the data being defined.
     class Meta < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/meta'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/org/name.rb
+++ b/lib/gobl/org/name.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Name represents what a human is called.
     class Name < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/name'
+
       # Unique identity code
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/org/note.rb
+++ b/lib/gobl/org/note.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Note represents a free text of additional information that may be added to a document.
     class Note < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/notes#/$defs/Note'
+
       # Key specifying subject of the text
       attribute? :key, NoteKey.optional
 

--- a/lib/gobl/org/note_key.rb
+++ b/lib/gobl/org/note_key.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # NoteKey identifies the type of note being edited
     class NoteKey < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/notes#/$defs/NoteKey'
+
       ENUM = {
         'goods' => 'Goods Description',
         'payment' => 'Terms of Payment',

--- a/lib/gobl/org/notes.rb
+++ b/lib/gobl/org/notes.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Notes holds an array of Note objects
     class Notes < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/notes'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/org/party.rb
+++ b/lib/gobl/org/party.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Party represents a person or business entity.
     class Party < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/party'
+
       # Internal ID used to identify the party inside a document.
       attribute? :id, GOBL::Types::String.optional
 

--- a/lib/gobl/org/person.rb
+++ b/lib/gobl/org/person.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Person represents a human, and how to contact them electronically.
     class Person < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/person'
+
       # Internal ID used to identify the person inside a document.
       attribute? :id, GOBL::Types::String.optional
 

--- a/lib/gobl/org/registration.rb
+++ b/lib/gobl/org/registration.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Registration is used in countries that require additional information to be associated with a company usually related to a specific registration office.
     class Registration < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/registration'
+
       attribute? :uuid, GOBL::UUID::UUID.optional
 
       attribute? :office, GOBL::Types::String.optional

--- a/lib/gobl/org/source_key.rb
+++ b/lib/gobl/org/source_key.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # SourceKey identifies the source of a tax identity
     class SourceKey < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/tax-identity#/$defs/SourceKey'
+
       ENUM = {
         'tax-agency' => 'Sourced directly from a tax agency',
         'passport' => 'A passport document',

--- a/lib/gobl/org/tax_identity.rb
+++ b/lib/gobl/org/tax_identity.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # TaxIdentity stores the details required to identify an entity for tax purposes.
     class TaxIdentity < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/tax-identity'
+
       # Unique universal identity code.
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/org/telephone.rb
+++ b/lib/gobl/org/telephone.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Telephone describes what is expected for a telephone number.
     class Telephone < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/telephone'
+
       # Unique identity code
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/org/unit.rb
+++ b/lib/gobl/org/unit.rb
@@ -10,6 +10,8 @@ module GOBL
   module Org
     # Unit describes how the quantity of the product should be interpreted.
     class Unit < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/org/unit'
+
       ENUM = {
         'g' => 'Metric grams',
         'kg' => 'Metric kilograms',

--- a/lib/gobl/pay/advance.rb
+++ b/lib/gobl/pay/advance.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # Advance represents a single payment that has been made already, such as a deposit on an intent to purchase, or as credit from a previous invoice which was later corrected or cancelled.
     class Advance < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/advance'
+
       # Unique identifier for this advance.
       attribute? :uuid, GOBL::UUID::UUID.optional
 

--- a/lib/gobl/pay/card.rb
+++ b/lib/gobl/pay/card.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # Card contains simplified card holder data as a reference for the customer.
     class Card < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/instructions#/$defs/Card'
+
       # Last 4 digits of the card's Primary Account Number (PAN).
       attribute :last4, GOBL::Types::String
 

--- a/lib/gobl/pay/credit_transfer.rb
+++ b/lib/gobl/pay/credit_transfer.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # CreditTransfer contains fields that can be used for making payments via a bank transfer or wire.
     class CreditTransfer < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/instructions#/$defs/CreditTransfer'
+
       # International Bank Account Number
       attribute? :iban, GOBL::Types::String.optional
 

--- a/lib/gobl/pay/direct_debit.rb
+++ b/lib/gobl/pay/direct_debit.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # DirectDebit defines the data that will be used to make the direct debit.
     class DirectDebit < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/instructions#/$defs/DirectDebit'
+
       # Unique identifier assigned by the payee for referencing the direct debit.
       attribute? :ref, GOBL::Types::String.optional
 

--- a/lib/gobl/pay/due_date.rb
+++ b/lib/gobl/pay/due_date.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # DueDate contains an amount that should be paid by the given date.
     class DueDate < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/terms#/$defs/DueDate'
+
       # When the payment is due.
       attribute :date, GOBL::Cal::Date
 

--- a/lib/gobl/pay/instructions.rb
+++ b/lib/gobl/pay/instructions.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # Instructions holds a set of instructions that determine how the payment has or should be made.
     class Instructions < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/instructions'
+
       # How payment is expected or has been arranged to be collected
       attribute :key, MethodKey
 

--- a/lib/gobl/pay/method_key.rb
+++ b/lib/gobl/pay/method_key.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # Method Key describes how a payment should be made
     class MethodKey < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/instructions#/$defs/MethodKey'
+
       ENUM = {
         'any' => 'Any method available, no preference',
         'card' => 'Credit or debit card',

--- a/lib/gobl/pay/online.rb
+++ b/lib/gobl/pay/online.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # Online provides the details required to make a payment online using a website
     class Online < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/instructions#/$defs/Online'
+
       # Descriptive name given to the online provider.
       attribute? :name, GOBL::Types::String.optional
 

--- a/lib/gobl/pay/term_key.rb
+++ b/lib/gobl/pay/term_key.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # Payment terms key
     class TermKey < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/terms#/$defs/TermKey'
+
       ENUM = {
         '' => 'Not yet defined',
         'end-of-month' => 'End of month',

--- a/lib/gobl/pay/terms.rb
+++ b/lib/gobl/pay/terms.rb
@@ -10,6 +10,8 @@ module GOBL
   module Pay
     # Terms defines when we expect the customer to pay, or have paid, for the contents of the document.
     class Terms < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/pay/terms'
+
       # Type of terms to be applied.
       attribute :key, TermKey
 

--- a/lib/gobl/stamp.rb
+++ b/lib/gobl/stamp.rb
@@ -9,6 +9,8 @@
 module GOBL
   # Stamp defines an official seal of approval from a third party like a governmental agency or intermediary and should thus be included in any official envelopes.
   class Stamp < GOBL::Struct
+    SCHEMA_ID = 'https://gobl.org/draft-0/envelope#/$defs/Stamp'
+
     # Identity of the agency used to create the stamp usually defined by each region.
     attribute :prv, GOBL::Org::Key
 

--- a/lib/gobl/tax/category.rb
+++ b/lib/gobl/tax/category.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Category contains the definition of a general type of tax inside a region.
     class Category < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/Category'
+
       attribute :code, GOBL::Org::Code
 
       attribute :name, GOBL::I18n::String

--- a/lib/gobl/tax/category_total.rb
+++ b/lib/gobl/tax/category_total.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # CategoryTotal groups together all rates inside a given category.
     class CategoryTotal < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/total#/$defs/CategoryTotal'
+
       attribute :code, GOBL::Org::Code
 
       attribute? :retained, GOBL::Types::Bool.optional

--- a/lib/gobl/tax/combo.rb
+++ b/lib/gobl/tax/combo.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Combo represents the tax combination of a category code and rate key.
     class Combo < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/set#/$defs/Combo'
+
       # Tax category code from those available inside a region.
       attribute :cat, GOBL::Org::Code
 

--- a/lib/gobl/tax/localities.rb
+++ b/lib/gobl/tax/localities.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Localities stores an array of locality objects used to describe areas sub-divisions inside a region.
     class Localities < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/Localities'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/tax/locality.rb
+++ b/lib/gobl/tax/locality.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Locality represents an area inside a region, like a province or a state, which shares the basic definitions of the region, but may vary in some validation rules.
     class Locality < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/Locality'
+
       # Code
       attribute :code, GOBL::L10n::Code
 

--- a/lib/gobl/tax/note.rb
+++ b/lib/gobl/tax/note.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Note represents a free text of additional information that may be added to a document.
     class Note < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/Note'
+
       # Key specifying subject of the text
       attribute? :key, NoteKey.optional
 

--- a/lib/gobl/tax/note_key.rb
+++ b/lib/gobl/tax/note_key.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # NoteKey identifies the type of note being edited
     class NoteKey < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/NoteKey'
+
       ENUM = {
         'goods' => 'Goods Description',
         'payment' => 'Terms of Payment',

--- a/lib/gobl/tax/rate.rb
+++ b/lib/gobl/tax/rate.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Rate defines a single rate inside a category
     class Rate < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/Rate'
+
       # Key identifies this rate within the system
       attribute :key, GOBL::Org::Key
 

--- a/lib/gobl/tax/rate_total.rb
+++ b/lib/gobl/tax/rate_total.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # RateTotal contains a sum of all the tax rates in the document with a matching category and rate.
     class RateTotal < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/total#/$defs/RateTotal'
+
       attribute? :key, GOBL::Org::Key.optional
 
       attribute :base, GOBL::Types.Constructor(GOBL::Num::Amount)

--- a/lib/gobl/tax/rate_total_surcharge.rb
+++ b/lib/gobl/tax/rate_total_surcharge.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # RateTotalSurcharge reflects the sum surcharges inside the rate.
     class RateTotalSurcharge < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/total#/$defs/RateTotalSurcharge'
+
       attribute :percent, GOBL::Types.Constructor(GOBL::Num::Percentage)
 
       attribute :amount, GOBL::Types.Constructor(GOBL::Num::Amount)

--- a/lib/gobl/tax/rate_value.rb
+++ b/lib/gobl/tax/rate_value.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # RateValue contains a percentage rate or fixed amount for a given date range.
     class RateValue < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/RateValue'
+
       # Date from which this value should be applied.
       attribute? :since, GOBL::Cal::Date.optional
 

--- a/lib/gobl/tax/region.rb
+++ b/lib/gobl/tax/region.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Region defines the holding structure for a regions categories and subsequent Rates and Values.
     class Region < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region'
+
       # Name of the region
       attribute :name, GOBL::I18n::String
 

--- a/lib/gobl/tax/scheme.rb
+++ b/lib/gobl/tax/scheme.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Scheme contains the definition of a scheme that belongs to a region and can be used to simplify validation processes for document contents.
     class Scheme < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/Scheme'
+
       # Key used to identify this scheme
       attribute :key, GOBL::Org::Key
 

--- a/lib/gobl/tax/schemes.rb
+++ b/lib/gobl/tax/schemes.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Schemes defines an array of scheme objects with helper functions.
     class Schemes < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/region#/$defs/Schemes'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/tax/set.rb
+++ b/lib/gobl/tax/set.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Set defines a list of tax categories and their rates to be used alongside taxable items.
     class Set < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/set'
+
       extend Forwardable
       include Enumerable
 

--- a/lib/gobl/tax/total.rb
+++ b/lib/gobl/tax/total.rb
@@ -10,6 +10,8 @@ module GOBL
   module Tax
     # Total contains a set of Category Totals which in turn contain all the accumulated taxes contained in the document.
     class Total < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/tax/total'
+
       # Grouping of all the taxes by their category
       attribute? :categories, GOBL::Types::Array.of(CategoryTotal).optional
 

--- a/lib/gobl/uuid/uuid.rb
+++ b/lib/gobl/uuid/uuid.rb
@@ -10,6 +10,8 @@ module GOBL
   module UUID
     # Universally Unique Identifier. We only recommend using versions 1 and 4 within GOBL.
     class UUID < GOBL::Struct
+      SCHEMA_ID = 'https://gobl.org/draft-0/uuid/uuid'
+
       attribute :_value, GOBL::Types::String
       private :_value
 

--- a/lib/id.rb
+++ b/lib/id.rb
@@ -43,5 +43,9 @@ module GOBL
     def to_s
       @id.to_s
     end
+
+    def ==(other)
+      to_s == other.to_s
+    end
   end
 end

--- a/spec/gobl/document_spec.rb
+++ b/spec/gobl/document_spec.rb
@@ -8,10 +8,22 @@ RSpec.describe GOBL::Document do
       gobl = File.read('spec/example/uncalculated_invoice.json')
       doc = described_class.from_json!(gobl)
 
+      expect(doc.schema).to eq('https://gobl.org/draft-0/bill/invoice')
+
       invoice = doc.extract
 
       expect(invoice.code).to eq('SAMPLE-001')
       expect(invoice.totals).to be_blank # Totals are calculated and missing in the document
+    end
+
+    it 'embeds a GOBL struct into a new document' do
+      json = File.read('spec/example/uncalculated_invoice.json')
+      invoice = GOBL::Bill::Invoice.from_json!(json)
+
+      doc = described_class.embed(invoice)
+
+      expect(doc.schema).to eq('https://gobl.org/draft-0/bill/invoice')
+      expect(doc.extract).to eq(invoice)
     end
   end
 end


### PR DESCRIPTION
* This PR adds the `GOBL::Document::embed` method that creates a new document embedding the GOBL struct given as a parameter (e.g. an invoice or message). The method takes care of injecting the right '$schema' key that it is required to identify the struct embedded in the document. It is the opposite of `GOBL::Document#extract`.
* This will enable Ruby developers to run operations (build, validate and sign) from instantiated invoices or messages. Example:

  ```ruby
  message = GOBL::Note::Message.new(content: 'Hello world!')
  doc = GOBL::Document.embed(message)
  GOBL.sign(doc) #=> Signed envelope containing the message
  ```

* One possible future enhancement (to be discussed) is to extend the operation methods so that they will automatically embed the struct given as parameter if that is not an envelope or a document already. To allow the following:

  ```ruby
  message = GOBL::Note::Message.new(content: 'Hello world!')
  GOBL.sign(message) #=> Signed envelope containing the message
  ```