### PR TITLE
Add Console command to mage

### DIFF
--- a/mage.go
+++ b/mage.go
@@ -62,3 +62,8 @@ func Shell() error {
 func YardServer() error {
 	return dockerRunCmd("gobl-ruby-yard", "8808", "yard", "server", "--reload")
 }
+
+// Runs an IRB session with the library required.
+func Console() error {
+	return dockerRunCmd(name, "", "sh", "-c", "irb -r ./lib/gobl")
+}


### PR DESCRIPTION
* This PR adds a `console` command to mage that runs an IRB session with the library required.